### PR TITLE
ci: add Codex CLI plugin manifest

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,0 +1,16 @@
+{
+  "name": "lamda",
+  "version": "0.1.0",
+  "description": "The most powerful Android RPA agent framework, next generation of mobile automation robots.",
+  "author": {
+    "name": "firerpa",
+    "url": "https://github.com/firerpa"
+  },
+  "homepage": "https://github.com/firerpa/lamda",
+  "repository": "https://github.com/firerpa/lamda",
+  "keywords": [
+    "mcp",
+    "codex"
+  ],
+  "mcpServers": "./.mcp.json"
+}

--- a/.github/workflows/codex-plugin-scanner.yml
+++ b/.github/workflows/codex-plugin-scanner.yml
@@ -1,0 +1,26 @@
+name: Codex Plugin Quality Gate
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: codex-plugin-scanner-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Codex plugin scanner
+        uses: hashgraph-online/hol-codex-plugin-scanner-action@e83708a91ae4812872aa2905b99ad559a55c74ab
+        with:
+          plugin_dir: "."
+          mode: scan
+          fail_on_severity: critical

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,10 @@
+{
+  "mcpServers": {
+    "lamda": {
+      "command": "npx",
+      "args": [
+        "firerpa-lamda"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
I opened this as a small metadata pass for the Codex plugin surface in the repo.

A couple of repo-specific details I checked first:
- The most powerful Android RPA agent framework, next generation of mobile automation robots
- FIRERPA Android ｜ AI-Powered Automation
- An all-in-one next-gen Android automation framework blending robust on-device services with AI-ready agents and extensible tool-calling capabilities

This PR adds the Codex plugin metadata, an `.mcp.json` starting point, and the scanner workflow.
If you want different command wiring or manifest metadata, I can adjust the branch.